### PR TITLE
Run gofmt

### DIFF
--- a/asn1.go
+++ b/asn1.go
@@ -10,14 +10,14 @@
 package certspotter
 
 import (
-	"errors"
 	"bytes"
-	"encoding/binary"
 	"encoding/asn1"
+	"encoding/binary"
+	"errors"
 	"unicode/utf8"
 )
 
-func stringFromByteSlice (chars []byte) string {
+func stringFromByteSlice(chars []byte) string {
 	runes := make([]rune, len(chars))
 	for i, ch := range chars {
 		runes[i] = rune(ch)
@@ -25,7 +25,7 @@ func stringFromByteSlice (chars []byte) string {
 	return string(runes)
 }
 
-func stringFromUint16Slice (chars []uint16) string {
+func stringFromUint16Slice(chars []uint16) string {
 	runes := make([]rune, len(chars))
 	for i, ch := range chars {
 		runes[i] = rune(ch)
@@ -33,7 +33,7 @@ func stringFromUint16Slice (chars []uint16) string {
 	return string(runes)
 }
 
-func stringFromUint32Slice (chars []uint32) string {
+func stringFromUint32Slice(chars []uint32) string {
 	runes := make([]rune, len(chars))
 	for i, ch := range chars {
 		runes[i] = rune(ch)
@@ -41,7 +41,7 @@ func stringFromUint32Slice (chars []uint32) string {
 	return string(runes)
 }
 
-func decodeASN1String (value *asn1.RawValue) (string, error) {
+func decodeASN1String(value *asn1.RawValue) (string, error) {
 	if !value.IsCompound && value.Class == 0 {
 		if value.Tag == 12 {
 			// UTF8String
@@ -59,14 +59,14 @@ func decodeASN1String (value *asn1.RawValue) (string, error) {
 			return stringFromByteSlice(value.Bytes), nil
 		} else if value.Tag == 30 {
 			// BMPString - Unicode, encoded in big-endian format using two octets
-			runes := make([]uint16, len(value.Bytes) / 2)
+			runes := make([]uint16, len(value.Bytes)/2)
 			if err := binary.Read(bytes.NewReader(value.Bytes), binary.BigEndian, runes); err != nil {
 				return "", errors.New("Malformed BMPString: " + err.Error())
 			}
 			return stringFromUint16Slice(runes), nil
 		} else if value.Tag == 28 {
 			// UniversalString - Unicode, encoded in big-endian format using four octets
-			runes := make([]uint32, len(value.Bytes) / 4)
+			runes := make([]uint32, len(value.Bytes)/4)
 			if err := binary.Read(bytes.NewReader(value.Bytes), binary.BigEndian, runes); err != nil {
 				return "", errors.New("Malformed UniversalString: " + err.Error())
 			}
@@ -75,4 +75,3 @@ func decodeASN1String (value *asn1.RawValue) (string, error) {
 	}
 	return "", errors.New("Not a string")
 }
-

--- a/asn1time.go
+++ b/asn1time.go
@@ -10,22 +10,22 @@
 package certspotter
 
 import (
-	"time"
-	"strconv"
-	"errors"
-	"unicode"
 	"encoding/asn1"
+	"errors"
+	"strconv"
+	"time"
+	"unicode"
 )
 
-func isDigit (b byte) bool {
+func isDigit(b byte) bool {
 	return unicode.IsDigit(rune(b))
 }
 
-func bytesToInt (bytes []byte) (int, error) {
+func bytesToInt(bytes []byte) (int, error) {
 	return strconv.Atoi(string(bytes))
 }
 
-func parseUTCTime (bytes []byte) (time.Time, error) {
+func parseUTCTime(bytes []byte) (time.Time, error) {
 	var err error
 	var year, month, day int
 	var hour, min, sec int
@@ -36,19 +36,29 @@ func parseUTCTime (bytes []byte) (time.Time, error) {
 		return time.Time{}, errors.New("UTCTime is too short")
 	}
 	year, err = bytesToInt(bytes[0:2])
-	if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+	}
 
 	month, err = bytesToInt(bytes[2:4])
-	if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+	}
 
 	day, err = bytesToInt(bytes[4:6])
-	if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+	}
 
 	hour, err = bytesToInt(bytes[6:8])
-	if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+	}
 
 	min, err = bytesToInt(bytes[8:10])
-	if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+	}
 
 	bytes = bytes[10:]
 
@@ -72,12 +82,16 @@ func parseUTCTime (bytes []byte) (time.Time, error) {
 				return time.Time{}, errors.New("UTCTime positive timezone offset is too short")
 			}
 			tzHour, err := bytesToInt(bytes[1:3])
-			if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+			}
 
 			tzMin, err := bytesToInt(bytes[3:5])
-			if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+			}
 
-			tz = time.FixedZone("", tzHour * 3600 + tzMin * 60)
+			tz = time.FixedZone("", tzHour*3600+tzMin*60)
 			bytes = bytes[5:]
 		} else if bytes[0] == '-' {
 			// -hhmm
@@ -85,12 +99,16 @@ func parseUTCTime (bytes []byte) (time.Time, error) {
 				return time.Time{}, errors.New("UTCTime negative timezone offset is too short")
 			}
 			tzHour, err := bytesToInt(bytes[1:3])
-			if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+			}
 
 			tzMin, err := bytesToInt(bytes[3:5])
-			if err != nil { return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("UTCTime contains invalid integer: " + err.Error())
+			}
 
-			tz = time.FixedZone("", -1 * (tzHour * 3600 + tzMin * 60))
+			tz = time.FixedZone("", -1*(tzHour*3600+tzMin*60))
 			bytes = bytes[5:]
 		}
 	} else {
@@ -111,7 +129,7 @@ func parseUTCTime (bytes []byte) (time.Time, error) {
 	return time.Date(year, time.Month(month), day, hour, min, sec, 0, tz), nil
 }
 
-func parseGeneralizedTime (bytes []byte) (time.Time, error) {
+func parseGeneralizedTime(bytes []byte) (time.Time, error) {
 	var err error
 	var year, month, day int
 	var hour, min, sec, ms int
@@ -122,16 +140,24 @@ func parseGeneralizedTime (bytes []byte) (time.Time, error) {
 		return time.Time{}, errors.New("GeneralizedTime is too short")
 	}
 	year, err = bytesToInt(bytes[0:4])
-	if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+	}
 
 	month, err = bytesToInt(bytes[4:6])
-	if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+	}
 
 	day, err = bytesToInt(bytes[6:8])
-	if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+	}
 
 	hour, err = bytesToInt(bytes[8:10])
-	if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+	if err != nil {
+		return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+	}
 
 	bytes = bytes[10:]
 
@@ -174,12 +200,16 @@ func parseGeneralizedTime (bytes []byte) (time.Time, error) {
 				return time.Time{}, errors.New("GeneralizedTime positive timezone offset is too short")
 			}
 			tzHour, err := bytesToInt(bytes[1:3])
-			if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+			}
 
 			tzMin, err := bytesToInt(bytes[3:5])
-			if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+			}
 
-			tz = time.FixedZone("", tzHour * 3600 + tzMin * 60)
+			tz = time.FixedZone("", tzHour*3600+tzMin*60)
 			bytes = bytes[5:]
 		} else if bytes[0] == '-' {
 			// -hhmm
@@ -187,12 +217,16 @@ func parseGeneralizedTime (bytes []byte) (time.Time, error) {
 				return time.Time{}, errors.New("GeneralizedTime negative timezone offset is too short")
 			}
 			tzHour, err := bytesToInt(bytes[1:3])
-			if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+			}
 
 			tzMin, err := bytesToInt(bytes[3:5])
-			if err != nil { return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error()) }
+			if err != nil {
+				return time.Time{}, errors.New("GeneralizedTime contains invalid integer: " + err.Error())
+			}
 
-			tz = time.FixedZone("", -1 * (tzHour * 3600 + tzMin * 60))
+			tz = time.FixedZone("", -1*(tzHour*3600+tzMin*60))
 			bytes = bytes[5:]
 		}
 	} else {
@@ -203,10 +237,10 @@ func parseGeneralizedTime (bytes []byte) (time.Time, error) {
 		return time.Time{}, errors.New("GeneralizedTime has trailing garbage")
 	}
 
-	return time.Date(year, time.Month(month), day, hour, min, sec, ms * 1000 * 1000, tz), nil
+	return time.Date(year, time.Month(month), day, hour, min, sec, ms*1000*1000, tz), nil
 }
 
-func decodeASN1Time (value *asn1.RawValue) (time.Time, error) {
+func decodeASN1Time(value *asn1.RawValue) (time.Time, error) {
 	if !value.IsCompound && value.Class == 0 {
 		if value.Tag == asn1.TagUTCTime {
 			return parseUTCTime(value.Bytes)

--- a/asn1time_test.go
+++ b/asn1time_test.go
@@ -15,31 +15,31 @@ import (
 )
 
 type timeTest struct {
-	in	string
-	ok	bool
-	out	time.Time
+	in  string
+	ok  bool
+	out time.Time
 }
 
 var utcTimeTests = []timeTest{
-	{ "9502101525Z", true, time.Date(1995, time.February, 10, 15, 25, 0, 0, time.UTC) },
-	{ "950210152542Z", true, time.Date(1995, time.February, 10, 15, 25, 42, 0, time.UTC) },
-	{ "1502101525Z", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC) },
-	{ "150210152542Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC) },
-	{ "1502101525+1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10 * 3600)) },
-	{ "1502101525-1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1 * (10 * 3600))) },
-	{ "1502101525+1035", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10 * 3600 + 35 * 60)) },
-	{ "1502101525-1035", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1 * (10 * 3600 + 35 * 60))) },
-	{ "150210152542+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10 * 3600)) },
-	{ "150210152542-1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1 * (10 * 3600))) },
-	{ "150210152542+1035", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10 * 3600 + 35 * 60)) },
-	{ "150210152542-1035", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1 * (10 * 3600 + 35 * 60))) },
-	{ "1502101525", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC) },
-	{ "150210152542", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC) },
-	{ "", false, time.Time{} },
-	{ "123", false, time.Time{} },
-	{ "150210152542-10", false, time.Time{} },
-	{ "150210152542F", false, time.Time{} },
-	{ "150210152542ZF", false, time.Time{} },
+	{"9502101525Z", true, time.Date(1995, time.February, 10, 15, 25, 0, 0, time.UTC)},
+	{"950210152542Z", true, time.Date(1995, time.February, 10, 15, 25, 42, 0, time.UTC)},
+	{"1502101525Z", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC)},
+	{"150210152542Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC)},
+	{"1502101525+1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10*3600))},
+	{"1502101525-1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1*(10*3600)))},
+	{"1502101525+1035", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10*3600+35*60))},
+	{"1502101525-1035", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1*(10*3600+35*60)))},
+	{"150210152542+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10*3600))},
+	{"150210152542-1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1*(10*3600)))},
+	{"150210152542+1035", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10*3600+35*60))},
+	{"150210152542-1035", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1*(10*3600+35*60)))},
+	{"1502101525", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC)},
+	{"150210152542", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC)},
+	{"", false, time.Time{}},
+	{"123", false, time.Time{}},
+	{"150210152542-10", false, time.Time{}},
+	{"150210152542F", false, time.Time{}},
+	{"150210152542ZF", false, time.Time{}},
 }
 
 func TestUTCTime(t *testing.T) {
@@ -62,44 +62,43 @@ func TestUTCTime(t *testing.T) {
 }
 
 var generalizedTimeTests = []timeTest{
-	{ "2015021015", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.UTC) },
-	{ "201502101525", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC) },
-	{ "20150210152542", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC) },
-	{ "20150210152542.123", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.UTC) },
-	{ "20150210152542.12", false, time.Time{} },
-	{ "20150210152542.1", false, time.Time{} },
-	{ "20150210152542.", false, time.Time{} },
+	{"2015021015", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.UTC)},
+	{"201502101525", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC)},
+	{"20150210152542", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC)},
+	{"20150210152542.123", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.UTC)},
+	{"20150210152542.12", false, time.Time{}},
+	{"20150210152542.1", false, time.Time{}},
+	{"20150210152542.", false, time.Time{}},
 
-	{ "2015021015Z", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.UTC) },
-	{ "201502101525Z", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC) },
-	{ "20150210152542Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC) },
-	{ "20150210152542.123Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.UTC) },
-	{ "20150210152542.12Z", false, time.Time{} },
-	{ "20150210152542.1Z", false, time.Time{} },
-	{ "20150210152542.Z", false, time.Time{} },
+	{"2015021015Z", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.UTC)},
+	{"201502101525Z", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.UTC)},
+	{"20150210152542Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.UTC)},
+	{"20150210152542.123Z", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.UTC)},
+	{"20150210152542.12Z", false, time.Time{}},
+	{"20150210152542.1Z", false, time.Time{}},
+	{"20150210152542.Z", false, time.Time{}},
 
-	{ "2015021015+1000", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.FixedZone("", 10 * 3600)) },
-	{ "201502101525+1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10 * 3600)) },
-	{ "20150210152542+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10 * 3600)) },
-	{ "20150210152542.123+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.FixedZone("", 10 * 3600)) },
-	{ "20150210152542.12+1000", false, time.Time{} },
-	{ "20150210152542.1+1000", false, time.Time{} },
-	{ "20150210152542.+1000", false, time.Time{} },
+	{"2015021015+1000", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.FixedZone("", 10*3600))},
+	{"201502101525+1000", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", 10*3600))},
+	{"20150210152542+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", 10*3600))},
+	{"20150210152542.123+1000", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.FixedZone("", 10*3600))},
+	{"20150210152542.12+1000", false, time.Time{}},
+	{"20150210152542.1+1000", false, time.Time{}},
+	{"20150210152542.+1000", false, time.Time{}},
 
-	{ "2015021015-0835", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.FixedZone("", -1 * (8 * 3600 + 35 * 60))) },
-	{ "201502101525-0835", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1 * (8 * 3600 + 35 * 60))) },
-	{ "20150210152542-0835", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1 * (8 * 3600 + 35 * 60))) },
-	{ "20150210152542.123-0835", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.FixedZone("", -1 * (8 * 3600 + 35 * 60))) },
-	{ "20150210152542.12-0835", false, time.Time{} },
-	{ "20150210152542.1-0835", false, time.Time{} },
-	{ "20150210152542.-0835", false, time.Time{} },
+	{"2015021015-0835", true, time.Date(2015, time.February, 10, 15, 0, 0, 0, time.FixedZone("", -1*(8*3600+35*60)))},
+	{"201502101525-0835", true, time.Date(2015, time.February, 10, 15, 25, 0, 0, time.FixedZone("", -1*(8*3600+35*60)))},
+	{"20150210152542-0835", true, time.Date(2015, time.February, 10, 15, 25, 42, 0, time.FixedZone("", -1*(8*3600+35*60)))},
+	{"20150210152542.123-0835", true, time.Date(2015, time.February, 10, 15, 25, 42, 123000000, time.FixedZone("", -1*(8*3600+35*60)))},
+	{"20150210152542.12-0835", false, time.Time{}},
+	{"20150210152542.1-0835", false, time.Time{}},
+	{"20150210152542.-0835", false, time.Time{}},
 
-
-	{ "", false, time.Time{} },
-	{ "123", false, time.Time{} },
-	{ "2015021015+1000Z", false, time.Time{} },
-	{ "2015021015x", false, time.Time{} },
-	{ "201502101525Zf", false, time.Time{} },
+	{"", false, time.Time{}},
+	{"123", false, time.Time{}},
+	{"2015021015+1000Z", false, time.Time{}},
+	{"2015021015x", false, time.Time{}},
+	{"201502101525Zf", false, time.Time{}},
 }
 
 func TestGeneralizedTime(t *testing.T) {

--- a/auditing.go
+++ b/auditing.go
@@ -10,19 +10,19 @@
 package certspotter
 
 import (
-	"software.sslmate.com/src/certspotter/ct"
 	"bytes"
 	"crypto/sha256"
+	"software.sslmate.com/src/certspotter/ct"
 )
 
-func reverseHashes (hashes []ct.MerkleTreeNode) {
-	for i := 0; i < len(hashes) / 2; i++ {
+func reverseHashes(hashes []ct.MerkleTreeNode) {
+	for i := 0; i < len(hashes)/2; i++ {
 		j := len(hashes) - i - 1
 		hashes[i], hashes[j] = hashes[j], hashes[i]
 	}
 }
 
-func VerifyConsistencyProof (proof ct.ConsistencyProof, first *ct.SignedTreeHead, second *ct.SignedTreeHead) (bool, *MerkleTreeBuilder) {
+func VerifyConsistencyProof(proof ct.ConsistencyProof, first *ct.SignedTreeHead, second *ct.SignedTreeHead) (bool, *MerkleTreeBuilder) {
 	if second.TreeSize < first.TreeSize {
 		// Can't be consistent if tree got smaller
 		return false, nil
@@ -46,7 +46,7 @@ func VerifyConsistencyProof (proof ct.ConsistencyProof, first *ct.SignedTreeHead
 	lastNode := second.TreeSize - 1
 
 	// While we're the right child, everything is in both trees, so move one level up.
-	for node % 2 == 1 {
+	for node%2 == 1 {
 		node /= 2
 		lastNode /= 2
 	}
@@ -68,7 +68,7 @@ func VerifyConsistencyProof (proof ct.ConsistencyProof, first *ct.SignedTreeHead
 	leftHashes = append(leftHashes, newHash)
 
 	for node > 0 {
-		if node % 2 == 1 {
+		if node%2 == 1 {
 			// node is a right child; left sibling exists in both trees
 			if len(proof) == 0 {
 				return false, nil
@@ -112,14 +112,14 @@ func VerifyConsistencyProof (proof ct.ConsistencyProof, first *ct.SignedTreeHead
 	return true, &MerkleTreeBuilder{stack: leftHashes, size: first.TreeSize}
 }
 
-func hashLeaf (leafBytes []byte) ct.MerkleTreeNode {
+func hashLeaf(leafBytes []byte) ct.MerkleTreeNode {
 	hasher := sha256.New()
 	hasher.Write([]byte{0x00})
 	hasher.Write(leafBytes)
 	return hasher.Sum(nil)
 }
 
-func hashChildren (left ct.MerkleTreeNode, right ct.MerkleTreeNode) ct.MerkleTreeNode {
+func hashChildren(left ct.MerkleTreeNode, right ct.MerkleTreeNode) ct.MerkleTreeNode {
 	hasher := sha256.New()
 	hasher.Write([]byte{0x01})
 	hasher.Write(left)
@@ -128,15 +128,15 @@ func hashChildren (left ct.MerkleTreeNode, right ct.MerkleTreeNode) ct.MerkleTre
 }
 
 type MerkleTreeBuilder struct {
-	stack		[]ct.MerkleTreeNode
-	size		uint64 // number of hashes added so far
+	stack []ct.MerkleTreeNode
+	size  uint64 // number of hashes added so far
 }
 
-func (builder *MerkleTreeBuilder) Add (hash ct.MerkleTreeNode) {
+func (builder *MerkleTreeBuilder) Add(hash ct.MerkleTreeNode) {
 	builder.stack = append(builder.stack, hash)
 	builder.size++
 	size := builder.size
-	for size % 2 == 0 {
+	for size%2 == 0 {
 		left, right := builder.stack[len(builder.stack)-2], builder.stack[len(builder.stack)-1]
 		builder.stack = builder.stack[:len(builder.stack)-2]
 		builder.stack = append(builder.stack, hashChildren(left, right))
@@ -144,7 +144,7 @@ func (builder *MerkleTreeBuilder) Add (hash ct.MerkleTreeNode) {
 	}
 }
 
-func (builder *MerkleTreeBuilder) Finish () ct.MerkleTreeNode {
+func (builder *MerkleTreeBuilder) Finish() ct.MerkleTreeNode {
 	if len(builder.stack) == 0 {
 		panic("MerkleTreeBuilder.Finish called on an empty tree")
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -10,18 +10,18 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"bytes"
 	"os/user"
-	"encoding/json"
-	"sync"
-	"strings"
 	"path/filepath"
-	"time"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"software.sslmate.com/src/certspotter"
 	"software.sslmate.com/src/certspotter/ct"
@@ -39,7 +39,7 @@ var stateDir string
 
 var printMutex sync.Mutex
 
-func homedir () string {
+func homedir() string {
 	home := os.Getenv("HOME")
 	if home != "" {
 		return home
@@ -51,15 +51,15 @@ func homedir () string {
 	panic("Unable to determine home directory")
 }
 
-func DefaultStateDir (programName string) string {
-	return filepath.Join(homedir(), "." + programName)
+func DefaultStateDir(programName string) string {
+	return filepath.Join(homedir(), "."+programName)
 }
 
-func DefaultConfigDir (programName string) string {
-	return filepath.Join(homedir(), "." + programName)
+func DefaultConfigDir(programName string) string {
+	return filepath.Join(homedir(), "."+programName)
 }
 
-func LogEntry (info *certspotter.EntryInfo) {
+func LogEntry(info *certspotter.EntryInfo) {
 	if !*noSave {
 		var alreadyPresent bool
 		var err error
@@ -84,24 +84,24 @@ func LogEntry (info *certspotter.EntryInfo) {
 	}
 }
 
-func defangLogUri (logUri string) string {
+func defangLogUri(logUri string) string {
 	return strings.Replace(strings.Replace(logUri, "://", "_", 1), "/", "_", -1)
 }
 
-func saveEvidence (logUri string, firstSTH *ct.SignedTreeHead, secondSTH *ct.SignedTreeHead, proof ct.ConsistencyProof) (string, string, string, error) {
+func saveEvidence(logUri string, firstSTH *ct.SignedTreeHead, secondSTH *ct.SignedTreeHead, proof ct.ConsistencyProof) (string, string, string, error) {
 	now := strconv.FormatInt(time.Now().Unix(), 10)
 
-	firstFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri) + ".inconsistent." + now + ".first")
+	firstFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri)+".inconsistent."+now+".first")
 	if err := certspotter.WriteSTHFile(firstFilename, firstSTH); err != nil {
 		return "", "", "", err
 	}
 
-	secondFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri) + ".inconsistent." + now + ".second")
+	secondFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri)+".inconsistent."+now+".second")
 	if err := certspotter.WriteSTHFile(secondFilename, secondSTH); err != nil {
 		return "", "", "", err
 	}
 
-	proofFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri) + ".inconsistent." + now + ".proof")
+	proofFilename := filepath.Join(stateDir, "evidence", defangLogUri(logUri)+".inconsistent."+now+".proof")
 	if err := certspotter.WriteProofFile(proofFilename, proof); err != nil {
 		return "", "", "", err
 	}
@@ -109,7 +109,7 @@ func saveEvidence (logUri string, firstSTH *ct.SignedTreeHead, secondSTH *ct.Sig
 	return firstFilename, secondFilename, proofFilename, nil
 }
 
-func Main (argStateDir string, processCallback certspotter.ProcessCallback) int {
+func Main(argStateDir string, processCallback certspotter.ProcessCallback) int {
 	stateDir = argStateDir
 
 	var logs []certspotter.LogInfo
@@ -171,9 +171,9 @@ func Main (argStateDir string, processCallback certspotter.ProcessCallback) int 
 		}
 
 		opts := certspotter.ScannerOptions{
-			BatchSize:     *batchSize,
-			NumWorkers:    *numWorkers,
-			Quiet:         !*verbose,
+			BatchSize:  *batchSize,
+			NumWorkers: *numWorkers,
+			Quiet:      !*verbose,
 		}
 		scanner := certspotter.NewScanner(logUri, logKey, &opts)
 
@@ -186,7 +186,7 @@ func Main (argStateDir string, processCallback certspotter.ProcessCallback) int 
 
 		if *verbose {
 			if prevSTH != nil {
-				log.Printf("Existing log; scanning %d new entries since previous scan (previous size %d, previous root hash = %x)", latestSTH.TreeSize - prevSTH.TreeSize, prevSTH.TreeSize, prevSTH.SHA256RootHash)
+				log.Printf("Existing log; scanning %d new entries since previous scan (previous size %d, previous root hash = %x)", latestSTH.TreeSize-prevSTH.TreeSize, prevSTH.TreeSize, prevSTH.SHA256RootHash)
 			} else if *allTime {
 				log.Printf("new log; scanning all %d entries in the log", latestSTH.TreeSize)
 			} else {

--- a/cmd/ctparsewatch/main.go
+++ b/cmd/ctparsewatch/main.go
@@ -14,11 +14,11 @@ import (
 	"os"
 
 	"software.sslmate.com/src/certspotter"
-	"software.sslmate.com/src/certspotter/ct"
 	"software.sslmate.com/src/certspotter/cmd"
+	"software.sslmate.com/src/certspotter/ct"
 )
 
-func DefaultStateDir () string {
+func DefaultStateDir() string {
 	if envVar := os.Getenv("CTPARSEWATCH_STATE_DIR"); envVar != "" {
 		return envVar
 	} else {
@@ -28,12 +28,12 @@ func DefaultStateDir () string {
 
 var stateDir = flag.String("state_dir", DefaultStateDir(), "Directory for storing state")
 
-func processEntry (scanner *certspotter.Scanner, entry *ct.LogEntry) {
+func processEntry(scanner *certspotter.Scanner, entry *ct.LogEntry) {
 	info := certspotter.EntryInfo{
-		LogUri:		scanner.LogUri,
-		Entry:		entry,
-		IsPrecert:	certspotter.IsPrecert(entry),
-		FullChain:	certspotter.GetFullChain(entry),
+		LogUri:    scanner.LogUri,
+		Entry:     entry,
+		IsPrecert: certspotter.IsPrecert(entry),
+		FullChain: certspotter.GetFullChain(entry),
 	}
 
 	info.CertInfo, info.ParseError = certspotter.MakeCertInfoFromLogEntry(entry)

--- a/ct/client/logclient.go
+++ b/ct/client/logclient.go
@@ -13,15 +13,15 @@ import (
 	"net/http"
 	"time"
 
-	"software.sslmate.com/src/certspotter/ct"
 	"github.com/mreiferson/go-httpclient"
+	"software.sslmate.com/src/certspotter/ct"
 )
 
 // URI paths for CT Log endpoints
 const (
-	GetSTHPath		= "/ct/v1/get-sth"
-	GetEntriesPath		= "/ct/v1/get-entries"
-	GetSTHConsistencyPath	= "/ct/v1/get-sth-consistency"
+	GetSTHPath            = "/ct/v1/get-sth"
+	GetEntriesPath        = "/ct/v1/get-entries"
+	GetSTHConsistencyPath = "/ct/v1/get-sth-consistency"
 )
 
 // LogClient represents a client for a given CT Log instance
@@ -84,7 +84,7 @@ func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
 	if err != nil {
 		return err
 	}
-//	req.Header.Set("Keep-Alive", "timeout=15, max=100")
+	//	req.Header.Set("Keep-Alive", "timeout=15, max=100")
 	resp, err := c.httpClient.Do(req)
 	var body []byte
 	if resp != nil {
@@ -97,7 +97,7 @@ func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode / 100 != 2 {
+	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("GET %s: %s (%s)", uri, resp.Status, string(body))
 	}
 	if err = json.Unmarshal(body, &res); err != nil {

--- a/ct/types.go
+++ b/ct/types.go
@@ -232,9 +232,9 @@ func (d *DigitallySigned) UnmarshalJSON(b []byte) error {
 
 // LogEntry represents the contents of an entry in a CT log, see section 3.1.
 type LogEntry struct {
-	Index    int64
-	Leaf     MerkleTreeLeaf
-	Chain    []ASN1Cert
+	Index     int64
+	Leaf      MerkleTreeLeaf
+	Chain     []ASN1Cert
 	LeafBytes []byte
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func doWildcardTest (t *testing.T, dnsName string, wildcard string, expected bool) {
+func doWildcardTest(t *testing.T, dnsName string, wildcard string, expected bool) {
 	if MatchesWildcard(dnsName, wildcard) != expected {
 		t.Errorf("MatchesWildcard(%q, %q) != %v", dnsName, wildcard, expected)
 	}

--- a/logs.go
+++ b/logs.go
@@ -10,26 +10,26 @@
 package certspotter
 
 import (
-	"encoding/base64"
 	"crypto"
 	"crypto/x509"
+	"encoding/base64"
 )
 
 type LogInfoFile struct {
-	Logs		[]LogInfo	`json:"logs"`
+	Logs []LogInfo `json:"logs"`
 }
 type LogInfo struct {
-	Description	string		`json:"description"`
-	Key		[]byte		`json:"key"`
-	Url		string		`json:"url"`
-	MMD		int		`json:"maximum_merge_delay"`
+	Description string `json:"description"`
+	Key         []byte `json:"key"`
+	Url         string `json:"url"`
+	MMD         int    `json:"maximum_merge_delay"`
 }
 
-func (info *LogInfo) FullURI () string {
+func (info *LogInfo) FullURI() string {
 	return "https://" + info.Url
 }
 
-func (info *LogInfo) ParsedPublicKey () (crypto.PublicKey, error) {
+func (info *LogInfo) ParsedPublicKey() (crypto.PublicKey, error) {
 	if info.Key != nil {
 		return x509.ParsePKIXPublicKey(info.Key)
 	} else {
@@ -92,13 +92,13 @@ var DefaultLogs = []LogInfo{
 var UnderwaterLogs = []LogInfo{
 	{
 		Description: "Google 'Submariner' log",
-		Key: mustDecodeBase64("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOfifIGLUV1Voou9JLfA5LZreRLSUMOCeeic8q3Dw0fpRkGMWV0Gtq20fgHQweQJeLVmEByQj9p81uIW4QkWkTw=="),
-		Url: "ct.googleapis.com/submariner",
-		MMD: 86400,
+		Key:         mustDecodeBase64("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOfifIGLUV1Voou9JLfA5LZreRLSUMOCeeic8q3Dw0fpRkGMWV0Gtq20fgHQweQJeLVmEByQj9p81uIW4QkWkTw=="),
+		Url:         "ct.googleapis.com/submariner",
+		MMD:         86400,
 	},
 }
 
-func mustDecodeBase64 (str string) []byte {
+func mustDecodeBase64(str string) []byte {
 	bytes, err := base64.StdEncoding.DecodeString(str)
 	if err != nil {
 		panic("MustDecodeBase64: " + err.Error())

--- a/precerts.go
+++ b/precerts.go
@@ -10,22 +10,23 @@
 package certspotter
 
 import (
-	"fmt"
-	"errors"
 	"bytes"
 	"encoding/asn1"
+	"errors"
+	"fmt"
 )
 
-func bitStringEqual (a, b *asn1.BitString) bool {
+func bitStringEqual(a, b *asn1.BitString) bool {
 	return a.BitLength == b.BitLength && bytes.Equal(a.Bytes, b.Bytes)
 }
 
 var (
-	oidExtensionAuthorityKeyId	= []int{2, 5, 29, 35}
-	oidExtensionSCT			= []int{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
-	oidExtensionCTPoison		= []int{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
+	oidExtensionAuthorityKeyId = []int{2, 5, 29, 35}
+	oidExtensionSCT            = []int{1, 3, 6, 1, 4, 1, 11129, 2, 4, 2}
+	oidExtensionCTPoison       = []int{1, 3, 6, 1, 4, 1, 11129, 2, 4, 3}
 )
-func ValidatePrecert (precertBytes []byte, tbsBytes []byte) error {
+
+func ValidatePrecert(precertBytes []byte, tbsBytes []byte) error {
 	precert, err := ParseCertificate(precertBytes)
 	if err != nil {
 		return errors.New("failed to parse pre-certificate: " + err.Error())
@@ -116,18 +117,18 @@ func ValidatePrecert (precertBytes []byte, tbsBytes []byte) error {
 
 	return nil
 }
-func ReconstructPrecertTBS (tbs *TBSCertificate) (*TBSCertificate, error) {
+func ReconstructPrecertTBS(tbs *TBSCertificate) (*TBSCertificate, error) {
 	precertTBS := TBSCertificate{
-		Version:		tbs.Version,
-		SerialNumber:		tbs.SerialNumber,
-		SignatureAlgorithm:	tbs.SignatureAlgorithm,
-		Issuer:			tbs.Issuer,
-		Validity:		tbs.Validity,
-		Subject:		tbs.Subject,
-		PublicKey:		tbs.PublicKey,
-		UniqueId:		tbs.UniqueId,
-		SubjectUniqueId:	tbs.SubjectUniqueId,
-		Extensions:		make([]Extension, 0, len(tbs.Extensions)),
+		Version:            tbs.Version,
+		SerialNumber:       tbs.SerialNumber,
+		SignatureAlgorithm: tbs.SignatureAlgorithm,
+		Issuer:             tbs.Issuer,
+		Validity:           tbs.Validity,
+		Subject:            tbs.Subject,
+		PublicKey:          tbs.PublicKey,
+		UniqueId:           tbs.UniqueId,
+		SubjectUniqueId:    tbs.SubjectUniqueId,
+		Extensions:         make([]Extension, 0, len(tbs.Extensions)),
 	}
 
 	for _, ext := range tbs.Extensions {

--- a/scanner.go
+++ b/scanner.go
@@ -13,14 +13,14 @@
 package certspotter
 
 import (
-//	"container/list"
+	//	"container/list"
+	"crypto"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
 	"sync/atomic"
 	"time"
-	"crypto"
-	"errors"
 
 	"software.sslmate.com/src/certspotter/ct"
 	"software.sslmate.com/src/certspotter/ct/client"
@@ -29,7 +29,7 @@ import (
 type ProcessCallback func(*Scanner, *ct.LogEntry)
 
 const (
-	FETCH_RETRIES = 10
+	FETCH_RETRIES    = 10
 	FETCH_RETRY_WAIT = 1
 )
 
@@ -48,28 +48,28 @@ type ScannerOptions struct {
 // Creates a new ScannerOptions struct with sensible defaults
 func DefaultScannerOptions() *ScannerOptions {
 	return &ScannerOptions{
-		BatchSize:     1000,
-		NumWorkers:    1,
-		Quiet:         false,
+		BatchSize:  1000,
+		NumWorkers: 1,
+		Quiet:      false,
 	}
 }
 
 // Scanner is a tool to scan all the entries in a CT Log.
 type Scanner struct {
 	// Base URI of CT log
-	LogUri				string
+	LogUri string
 
 	// Public key of the log
-	publicKey			crypto.PublicKey
+	publicKey crypto.PublicKey
 
 	// Client used to talk to the CT log instance
-	logClient			*client.LogClient
+	logClient *client.LogClient
 
 	// Configuration options for this Scanner instance
-	opts				ScannerOptions
+	opts ScannerOptions
 
 	// Stats
-	certsProcessed			int64
+	certsProcessed int64
 }
 
 // fetchRange represents a range of certs to fetch from a CT log
@@ -233,7 +233,7 @@ func (s *Scanner) CheckConsistency(first *ct.SignedTreeHead, second *ct.SignedTr
 }
 
 func (s *Scanner) Scan(startIndex int64, endIndex int64, processCert ProcessCallback, treeBuilder *MerkleTreeBuilder) error {
-	s.Log("Starting scan...");
+	s.Log("Starting scan...")
 
 	s.certsProcessed = 0
 	startTime := time.Now()


### PR DESCRIPTION
This is the result of running `gofmt -s **/*.go`, which mechanically formats the code and simplifies few things that are unambiguous. Using gofmt is standard in the Go ecosystem. No actual code has changed, these are purely whitespace/formatting changes. 