### PR TITLE
Proxy support - Addition of -proxyurl <proxy> command line argument

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -120,7 +120,8 @@ func makeLogHandle(logInfo *certspotter.LogInfo) (*logHandle, error) {
 		BatchSize:  *batchSize,
 		NumWorkers: *numWorkers,
 		Quiet:      !*verbose,
-		ProxyURL:   proxyURL})
+		ProxyURL:   proxyURL,
+	})
 
 	ctlog.state, err = state.OpenLogState(logInfo)
 	if err != nil {

--- a/ct/client/logclient.go
+++ b/ct/client/logclient.go
@@ -86,9 +86,10 @@ type addChainResponse struct {
 // New constructs a new LogClient instance.
 // |uri| is the base URI of the CT log instance to interact with, e.g.
 // http://ct.googleapis.com/pilot
-func New(uri string) *LogClient {
+func New(uri string, proxyURL *url.URL) *LogClient {
 	var c LogClient
 	c.uri = uri
+
 	transport := &httpclient.Transport{
 		ConnectTimeout:        10 * time.Second,
 		RequestTimeout:        60 * time.Second,
@@ -105,6 +106,9 @@ func New(uri string) *LogClient {
 			// updating should a log ever change to a different CA.)
 			InsecureSkipVerify: true,
 		},
+	}
+	if proxyURL != nil {
+		transport.Proxy = http.ProxyURL(proxyURL)
 	}
 	c.httpClient = &http.Client{Transport: transport}
 	return &c

--- a/scanner.go
+++ b/scanner.go
@@ -13,6 +13,7 @@
 package certspotter
 
 import (
+	"net/url"
 	//	"container/list"
 	"bytes"
 	"crypto"
@@ -44,6 +45,9 @@ type ScannerOptions struct {
 
 	// Don't print any status messages to stdout
 	Quiet bool
+
+	//
+	ProxyURL *url.URL
 }
 
 // Creates a new ScannerOptions struct with sensible defaults
@@ -52,6 +56,7 @@ func DefaultScannerOptions() *ScannerOptions {
 		BatchSize:  1000,
 		NumWorkers: 1,
 		Quiet:      false,
+		ProxyURL:   nil,
 	}
 }
 
@@ -315,7 +320,7 @@ func NewScanner(logUri string, logId []byte, publicKey crypto.PublicKey, opts *S
 	scanner.LogUri = logUri
 	scanner.LogId = logId
 	scanner.publicKey = publicKey
-	scanner.logClient = client.New(logUri)
+	scanner.logClient = client.New(logUri, opts.ProxyURL)
 	scanner.opts = *opts
 	return &scanner
 }


### PR DESCRIPTION
At the moment, all the usual proxy enablement options for golang programs (http_proxy environment variable) do not work, as the way the Proxy argument to the net/http client is current passed into the http transport effectively disallows the use of a proxy. This code change adds a command-line argument -proxyurl which allows the specification of a proxy to be used for the certspotter connection, which is relatively common in enterprise environments.