### PR TITLE
Download log updates in parallel

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -347,11 +347,13 @@ func Main(statePath string, processCallback certspotter.ProcessCallback) int {
 		go processLog(&logs[i], processCallback)
 	}
 
-	wg.Wait()
+	go func() {
+		for i := range rcode {
+			exitCode |= i
+		}
+	}()
 
-	for i := range rcode {
-		exitCode |= i
-	}
+	wg.Wait()
 
 	if state.IsFirstRun() && exitCode == 0 {
 		if err := state.WriteOnceFile(); err != nil {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -246,7 +246,7 @@ func (ctlog *logHandle) scan(processCallback certspotter.ProcessCallback) error 
 
 func processLog(logInfo *certspotter.LogInfo, processCallback certspotter.ProcessCallback) int {
 	defer wg.Done()
-	log.SetPrefix(os.Args[0] + ": " + logInfo.Url + ": ")
+	log.SetPrefix(os.Args[0] + ": ")
 
 	ctlog, err := makeLogHandle(logInfo)
 	if err != nil {


### PR DESCRIPTION
Download updates from the various logs in parallel, instead of serially.

I didn't really scrutinize the whole code base to ensure everything is thread-safe.  My testing seems to work.