### PR TITLE
certspotterVersion: also allow -X=main.Version

### DIFF
--- a/cmd/certspotter/main.go
+++ b/cmd/certspotter/main.go
@@ -30,10 +30,14 @@ import (
 )
 
 var programName = os.Args[0]
+var Version = ""
 
 const defaultLogList = "https://loglist.certspotter.org/monitor.json"
 
 func certspotterVersion() string {
+	if Version != "" {
+		return Version
+	}
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return "unknown"


### PR DESCRIPTION
`debug.ReadBuildInfo()` doesn't work for the Debian package, where there is no git repository (at best; could be the Debian packaging one). The go module doesn't have a version either.

Add a quick shortcut at the top, that sets the version to `main.Version` if it's non-empty -- which is by default, so no change in behavior.

Effectively, this allows one to use the standard `-ldflags=-X=main.Version` to set the version, like we intend to do in the Debian package.