### PR TITLE
Make sendmail path configurable

### DIFF
--- a/cmd/certspotter/main.go
+++ b/cmd/certspotter/main.go
@@ -201,9 +201,14 @@ func main() {
 		Verbose:             flags.verbose,
 		Script:              flags.script,
 		ScriptDir:           defaultScriptDir(),
+		SendmailPath:        "/usr/sbin/sendmail",
 		Email:               flags.email,
 		Stdout:              flags.stdout,
 		HealthCheckInterval: flags.healthcheck,
+	}
+
+	if envVar := os.Getenv("SENDMAIL_PATH"); envVar != "" {
+		config.SendmailPath = envVar
 	}
 
 	emailFileExists := false

--- a/man/certspotter.md
+++ b/man/certspotter.md
@@ -218,6 +218,10 @@ and non-zero when a serious error occurs.
 :   URL of proxy server for making HTTPS requests.  `http://`, `https://`, and
     `socks5://` URLs are supported.  By default, no proxy server is used.
 
+`SENDMAIL_PATH`
+
+:   Path to the sendmail binary. Defaults to `/usr/sbin/sendmail`.
+
 # SEE ALSO
 
 certspotter-script(8)

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	WatchList           WatchList
 	Verbose             bool
 	SaveCerts           bool
+	SendmailPath        string
 	Script              string
 	ScriptDir           string
 	Email               []string

--- a/monitor/notify.go
+++ b/monitor/notify.go
@@ -36,7 +36,7 @@ func notify(ctx context.Context, config *Config, notif notification) error {
 	}
 
 	if len(config.Email) > 0 {
-		if err := sendEmail(ctx, config.Email, notif); err != nil {
+		if err := sendEmail(ctx, config.SendmailPath, config.Email, notif); err != nil {
 			return err
 		}
 	}
@@ -62,7 +62,7 @@ func writeToStdout(notif notification) {
 	os.Stdout.WriteString(notif.Text() + "\n")
 }
 
-func sendEmail(ctx context.Context, to []string, notif notification) error {
+func sendEmail(ctx context.Context, sendmailPath string, to []string, notif notification) error {
 	stdin := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 
@@ -77,7 +77,7 @@ func sendEmail(ctx context.Context, to []string, notif notification) error {
 	args := []string{"-i", "--"}
 	args = append(args, to...)
 
-	sendmail := exec.CommandContext(ctx, "/usr/sbin/sendmail", args...)
+	sendmail := exec.CommandContext(ctx, sendmailPath, args...)
 	sendmail.Stdin = stdin
 	sendmail.Stderr = stderr
 


### PR DESCRIPTION
Some distributions, such as NixOS (which I [have created a certspotter module](https://github.com/NixOS/nixpkgs/pull/262915) for), don't follow the FHS and don't have `/usr`. Even on distributions that follow the FHS, `/usr/sbin` isn't guaranteed to exist. Finally, it's just nice for this to be configurable, as there are many sendmail implementations, so nearly all software that uses sendmail has this option.