### PR TITLE
Indicate known certificates in sent mails feature 

### DIFF
--- a/man/certspotter.md
+++ b/man/certspotter.md
@@ -115,6 +115,11 @@ You can use Cert Spotter to detect:
     certspotter reads the watch list only when starting up, so you must restart
     certspotter if you change it.
 
+-keylist *PATH*
+
+:   File containing known key information, one per line. A line consist of a
+    identifier and the sha256 of the public key separated by semi colon
+
 # NOTIFICATIONS
 
 When certspotter detects a certificate matching your watchlist, or encounters

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	State               StateProvider
 	StartAtEnd          bool
 	WatchList           WatchList
+	KeyList             KeyList
 	Verbose             bool
 	HealthCheckInterval time.Duration
 }

--- a/monitor/discoveredcert.go
+++ b/monitor/discoveredcert.go
@@ -23,6 +23,7 @@ import (
 
 type DiscoveredCert struct {
 	WatchItem    WatchItem
+	KeyItem      KeyItem
 	LogEntry     *LogEntry
 	Info         *certspotter.CertInfo
 	Chain        []ct.ASN1Cert // first entry is the leaf certificate or precertificate
@@ -172,5 +173,9 @@ func certNotificationText(cert *DiscoveredCert, paths *certPaths) string {
 }
 
 func certNotificationSummary(cert *DiscoveredCert) string {
-	return fmt.Sprintf("Certificate Discovered for %s", cert.WatchItem)
+        keytext := ""
+        if cert.KeyItem.String() != "" {
+	        keytext = fmt.Sprintf(" (known as %s)", cert.KeyItem.String())
+        }
+	return fmt.Sprintf("Certificate Discovered for %s%s", cert.WatchItem, keytext)
 }

--- a/monitor/keylist.go
+++ b/monitor/keylist.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2016, 2023 Opsmate, Inc.
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License, v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// This software is distributed WITHOUT A WARRANTY OF ANY KIND.
+// See the Mozilla Public License for details.
+
+package monitor
+
+import (
+	"bufio"
+	"encoding/hex"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"software.sslmate.com/src/certspotter"
+	"strings"
+)
+
+type KeyItem struct {
+	domain       string
+	keyinfo      string
+}
+
+type KeyList []KeyItem
+
+func ParseKeyItem(str string) (KeyItem, error) {
+	fields := strings.Split(str, ";")
+	if len(fields) == 0 {
+		return KeyItem{}, fmt.Errorf("empty domain")
+	}
+	if len(fields) == 1 {
+		return KeyItem{}, fmt.Errorf("empty key info")
+	}
+	return KeyItem{
+		domain:       fields[0],
+		keyinfo:      fields[1],
+	}, nil
+}
+
+func ReadKeyList(reader io.Reader) (KeyList, error) {
+	items := make(KeyList, 0, 50)
+	scanner := bufio.NewScanner(reader)
+	lineNo := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNo++
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		item, err := ParseKeyItem(line)
+		if err != nil {
+			return nil, fmt.Errorf("%w on line %d", err, lineNo)
+		}
+		items = append(items, item)
+	}
+	return items, scanner.Err()
+}
+
+func (item KeyItem) String() string {
+	return item.domain
+}
+
+func (list KeyList) Matches(certInfo *certspotter.CertInfo) (bool, KeyItem) {
+     
+	for _, item := range list {
+	        // better would be to convert the input and compare the bytes (no uppercase/lower-case issue)
+	        pub := sha256.Sum256(certInfo.TBS.PublicKey.FullBytes)
+		sum := hex.EncodeToString(pub[:])
+		if sum == item.keyinfo {
+			return true, item
+		}
+	}
+	return false, KeyItem{}
+}

--- a/monitor/process.go
+++ b/monitor/process.go
@@ -91,11 +91,13 @@ func processCertificate(ctx context.Context, config *Config, entry *LogEntry, ce
 	if !matched {
 		return nil
 	}
+	matched, keyItem := config.KeyList.Matches(certInfo)
 
 	cert := &DiscoveredCert{
 		WatchItem:    watchItem,
 		LogEntry:     entry,
 		Info:         certInfo,
+		KeyItem:      keyItem,
 		Chain:        chain,
 		TBSSHA256:    sha256.Sum256(certInfo.TBS.Raw),
 		SHA256:       sha256.Sum256(chain[0]),


### PR DESCRIPTION
Fixes #88. I switched form direct parameters to sha256 of the pubkey.

Note that is the first time I do something in go, so it's probably not the best solution (i.e. see todo comment).

Short perl script to create the keylist from public keys and rsa/ec private keys.
```
#!/usr/bin/perl -w

use strict;

for my $k (@ARGV)
{
  my $name = $k;
  $name =~ s/\.[a-z]+$//;
  $name =~ s/^.*[\/\\]//;

  my $sum;
  if($k =~ /\.pem$/)
  {
    $sum = (split(" ", `openssl x509 -in $k -pubkey -noout 2>/dev/null|sed '1d;\$d' |base64 -d |sha256sum`))[0];
  }
  elsif($k =~ /\.key$/)
  {
    $sum = (split(" ", `openssl rsa -in $k -pubout 2>/dev/null|sed '1d;\$d' |base64 -d |sha256sum`))[0];
    if($sum eq "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
    {
      $sum = (split(" ", `openssl ec -in $k -pubout 2>/dev/null|sed '1d;\$d' |base64 -d |sha256sum`))[0];
    }
  }
  print "$name;$sum\n";
}
```

Final test is still running. I'll update in case I find an error.